### PR TITLE
search nace without accented characters

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -6,6 +6,7 @@ import {
   numberInputRegexp,
   formatPsc,
   formatIco,
+  translit,
 } from '../src/lib/utils'
 
 describe('utils', () => {
@@ -106,6 +107,12 @@ describe('utils', () => {
 
     it('should remove last number and space when using backspace after second space', () => {
       expect(formatIco('12 345', '12 345 ')).toBe('12 34')
+    })
+  })
+
+  describe('#translit', () => {
+    it('should replace accented characters', () => {
+      expect(translit('ľščťžýáíéúäôň-qwe123')).toBe('lsctzyaieuaon-qwe123')
     })
   })
 })

--- a/src/components/Nace.module.css
+++ b/src/components/Nace.module.css
@@ -1,3 +1,15 @@
+.autocompleteField::after {
+  content: '▼' !important;
+  position: absolute;
+  width: 30px;
+  height: 36px;
+  line-height: 36px;
+  right: 2px;
+  top: 35px;
+  pointer-events: none;
+  color: rgba(0,0,0,.7);
+  background: white;
+}
 .autocompleteFieldLoading {
   position: relative;
 }
@@ -5,9 +17,9 @@
   padding-right: 40px;
 }
 .autocompleteFieldLoading::after {
-  content: '';
+  content: '' !important;
   position: absolute;
-  width: 40px;
+  width: 30px;
   height: 40px;
   right: 5px;
   top: 32px;

--- a/src/components/Nace.tsx
+++ b/src/components/Nace.tsx
@@ -13,7 +13,7 @@ const options = {
   location: 30,
   distance: 100,
   minMatchCharLength: 2,
-  keys: ['code', 'label'],
+  keys: ['code', 'label', 'translit'],
 }
 
 function useFuse<T>(data: T[]): Fuse<T, { includeScore: true }> {
@@ -109,6 +109,7 @@ export const Nace: React.FC<Props> = ({
         meta.touched && meta.error && 'govuk-form-group--error',
         isLoading ? [styles.autocompleteFieldLoading] : '',
         styles.relative,
+        styles.autocompleteField,
       ])}
     >
       <label className="govuk-label govuk-!-font-weight-bold" htmlFor={name}>
@@ -136,7 +137,8 @@ export const Nace: React.FC<Props> = ({
         inputProps={inputProps}
         theme={theme}
         shouldRenderSuggestions={() => true}
-        onSuggestionSelected={(_event, { suggestion }) => {
+        onSuggestionSelected={(event, { suggestion }) => {
+          event.preventDefault()
           helpers.setValue(formatNace(suggestion))
         }}
       />

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -6,6 +6,7 @@ import {
 } from '../types/api'
 import { TemplateParams } from './sendinblue'
 import { TaxForm } from '../types/TaxForm'
+import { translit } from './utils'
 
 export const getCity = async (zip: string) => {
   const response = await fetch(
@@ -43,7 +44,11 @@ export const saveEmail = async (
 }
 
 export const getNace = async () => {
-  return (await fetch(`nace.json`)).json()
+  return fetch(`nace.json`)
+    .then((response) => response.json())
+    .then((values) => {
+      return values.map((item) => ({ ...item, translit: translit(item.label) }))
+    })
 }
 
 export const downloadPdf = async (taxForm: TaxForm) => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -66,3 +66,6 @@ export const formatRodneCislo = (value: string, withSlash = true) =>
   value
     .replace(/\D/g, '')
     .replace(/^(\d{6})(\d{4})$/, withSlash ? '$1 / $2' : '$1$2')
+
+export const translit = (value: string) =>
+  value.normalize('NFD').replace(/[\u0300-\u036f]/g, '')


### PR DESCRIPTION
Ked sa nacita `nace.json` tak pridame do `translit` string - nazov bez diakritiky. Umoznime tak vyhladavanie NACE bez diakritiky.

Trello: 
* https://trello.com/c/zL0Abv8G/71-bug-vyber-sknace-cez-autocomplete-klavesa-enter-odosle-formular
* https://trello.com/c/wHXpvMUi/24-dropdownpng