### PR TITLE
move alpha banner above headline

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -33,6 +33,20 @@ const Layout: React.FC<Props> = ({
       )}
     </Head>
     <Header />
+
+    <div className="govuk-width-container content-container">
+      <div className="govuk-phase-banner">
+        <p className="govuk-phase-banner__content">
+          <strong className="govuk-tag govuk-phase-banner__content__tag">
+            BETA
+          </strong>
+          <span className="govuk-phase-banner__text">
+            Táto služba je vo vývoji.
+          </span>
+        </p>
+      </div>
+    </div>
+
     <div className="sdn-headline">
       <div className="sdn-headline__container govuk-width-container">
         <div className="sdn-headline__part">
@@ -42,21 +56,9 @@ const Layout: React.FC<Props> = ({
     </div>
 
     <div className="govuk-width-container content-container">
-      <div className="govuk-phase-banner">
-        <p className="govuk-phase-banner__content">
-          <strong className="govuk-tag govuk-phase-banner__content__tag">
-            Alpha
-          </strong>
-          <span className="govuk-phase-banner__text">
-            Táto služba je vo vývoji.
-          </span>
-        </p>
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-two-thirds">{children}</div>
       </div>
-      <main className="govuk-main-wrapper">
-        <div className="govuk-grid-row">
-          <div className="govuk-grid-column-two-thirds">{children}</div>
-        </div>
-      </main>
     </div>
     <Debug
       taxFormUserInput={taxFormUserInput}


### PR DESCRIPTION
Trello: https://trello.com/c/o5H4iX06/28-alpha-banner-premiestnit-hore-ako-je-govuk

<img width="1134" alt="Screenshot 2020-06-13 at 13 06 12" src="https://user-images.githubusercontent.com/1561771/84567132-d769c200-ad76-11ea-806e-ee4166e3812d.png">
