### PR TITLE
Generate and download xml and pdf server side

### DIFF
--- a/src/components/EmailForm.tsx
+++ b/src/components/EmailForm.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 import { CheckboxSmall, Input } from './FormComponents'
 import { sendEmailTemplate } from '../lib/api'
 import { EmailUserInput } from '../types/UserInput'
-import { TaxForm } from '../types/TaxForm'
+import { TaxFormUserInput } from '../types/TaxFormUserInput'
 
 const getErrorMessage = (code: string, message: string) => {
   switch (code) {
@@ -22,21 +22,21 @@ export interface EmailFormProps {
   label: string
   hint?: string
   params: Record<string, any>
-  taxForm: TaxForm
+  taxFormUserInput: TaxFormUserInput
   saveForm: (email: string, newsletter: boolean) => void
 }
 export const EmailForm = ({
   label,
   hint,
   params,
-  taxForm,
+  taxFormUserInput,
   saveForm,
 }: EmailFormProps) => {
   const handleSubmit = async ({ email, newsletter }, { setFieldError }) => {
     const { messageId, code, message } = await sendEmailTemplate(
       email,
       { ...params, newsletter: !!newsletter } as any,
-      taxForm,
+      taxFormUserInput,
     )
     if (messageId) {
       saveForm(email, !!newsletter)

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -5,7 +5,7 @@ import {
   SaveEmailResponse,
 } from '../types/api'
 import { TemplateParams } from './sendinblue'
-import { TaxForm } from '../types/TaxForm'
+import { TaxFormUserInput } from '../types/TaxFormUserInput'
 import { translit } from './utils'
 
 export const getCity = async (zip: string) => {
@@ -31,7 +31,7 @@ export const getNgoByName = async (
 export const sendEmailTemplate = async (
   email: string,
   params: TemplateParams,
-  taxForm: TaxForm,
+  taxFormUserInput: TaxFormUserInput,
   template: 'tax' | 'postpone' = 'tax',
 ): Promise<SaveEmailResponse> => {
   return fetch(`/api/email?tpl=${template}`, {
@@ -40,7 +40,7 @@ export const sendEmailTemplate = async (
       accept: 'application/json',
       'content-type': 'application/json',
     },
-    body: JSON.stringify({ email, params, taxForm }),
+    body: JSON.stringify({ email, params, taxFormUserInput }),
   }).then((response) => response.json())
 }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -51,14 +51,3 @@ export const getNace = async () => {
       return values.map((item) => ({ ...item, translit: translit(item.label) }))
     })
 }
-
-export const downloadPdf = async (taxForm: TaxForm) => {
-  return fetch('/api/pdf', {
-    method: 'POST',
-    headers: {
-      accept: 'application/json',
-      'content-type': 'application/json',
-    },
-    body: JSON.stringify({ taxForm }),
-  }).then((response) => response.blob())
-}

--- a/src/pages/api/email.ts
+++ b/src/pages/api/email.ts
@@ -32,7 +32,7 @@ export default async (
     return res.send({ message: 'Invalid params' })
   }
 
-  const taxForm: TaxForm = calculate(setDate(taxFormUserInput))
+  const taxForm: TaxForm = calculate(setDate(taxFormUserInput, new Date()))
   const attachmentXml = convertToXML(taxForm)
   const attachmentPdf = buildPdf(taxForm)
 

--- a/src/pages/api/email.ts
+++ b/src/pages/api/email.ts
@@ -32,7 +32,7 @@ export default async (
     return res.send({ message: 'Invalid params' })
   }
 
-  const taxForm: TaxForm = calculate(setDate(taxFormUserInput, new Date()))
+  const taxForm: TaxForm = calculate(setDate(taxFormUserInput))
   const attachmentXml = convertToXML(taxForm)
   const attachmentPdf = buildPdf(taxForm)
 

--- a/src/pages/api/email.ts
+++ b/src/pages/api/email.ts
@@ -8,6 +8,9 @@ import {
 import { convertToXML } from '../../lib/xml/xmlConverter'
 import { setDate } from '../../lib/utils'
 import { buildPdf } from './pdf'
+import { TaxForm } from '../../types/TaxForm'
+import { TaxFormUserInput } from '../../types/TaxFormUserInput'
+import { calculate } from '../../lib/calculation'
 
 const templates = {
   tax: parseInt(process.env.sendinblue_tpl_tax, 10),
@@ -22,14 +25,15 @@ export default async (
   const email = `${req.body.email}`
   const params = req.body.params as TemplateParams
   const template = req.query.tpl ? `${req.query.tpl}` : 'tax'
-  const taxForm = req.body.taxForm
+  const taxFormUserInput: TaxFormUserInput = req.body.taxFormUserInput
 
-  if (!email || !params || !template || !taxForm) {
+  if (!email || !params || !template || !taxFormUserInput) {
     res.statusCode = 400
     return res.send({ message: 'Invalid params' })
   }
 
-  const attachmentXml = convertToXML(setDate(taxForm))
+  const taxForm: TaxForm = calculate(setDate(taxFormUserInput))
+  const attachmentXml = convertToXML(taxForm)
   const attachmentPdf = buildPdf(taxForm)
 
   try {

--- a/src/pages/api/pdf.ts
+++ b/src/pages/api/pdf.ts
@@ -670,12 +670,16 @@ export default async (
   req: NextApiRequest,
   res: NextApiResponse,
 ): Promise<void> => {
-  const form: TaxForm = req.body && req.body.taxForm
+  const form: TaxForm = req.body
 
   if (!form) {
     return res.status(500).json({ error: 'invalid data' })
   }
 
+  res.setHeader(
+    'content-disposition',
+    'attachment; filename=danove_priznanie.pdf',
+  )
   res.writeHead(200, { 'Content-Type': 'application/pdf' })
 
   buildPdf(form, res)

--- a/src/pages/api/pdf.ts
+++ b/src/pages/api/pdf.ts
@@ -673,12 +673,13 @@ export default async (
   req: NextApiRequest,
   res: NextApiResponse,
 ): Promise<void> => {
-  if (!req.body.taxFormUserInput) {
+  const rawTaxFormUserInput = req.body.taxFormUserInput
+  if (!rawTaxFormUserInput) {
     return res.status(500).json({ error: 'invalid data' })
   }
 
-  const formInput: TaxFormUserInput = JSON.parse(req.body.taxFormUserInput)
-  const form: TaxForm = calculate(setDate(formInput))
+  const taxFormUserInput: TaxFormUserInput = JSON.parse(rawTaxFormUserInput)
+  const taxForm: TaxForm = calculate(setDate(taxFormUserInput))
 
   res.setHeader(
     'content-disposition',
@@ -686,7 +687,7 @@ export default async (
   )
   res.writeHead(200, { 'Content-Type': 'application/pdf' })
 
-  buildPdf(form, res)
+  buildPdf(taxForm, res)
 
   res.end()
 }

--- a/src/pages/api/pdf.ts
+++ b/src/pages/api/pdf.ts
@@ -679,7 +679,7 @@ export default async (
   }
 
   const taxFormUserInput: TaxFormUserInput = JSON.parse(rawTaxFormUserInput)
-  const taxForm: TaxForm = calculate(setDate(taxFormUserInput))
+  const taxForm: TaxForm = calculate(setDate(taxFormUserInput, new Date()))
 
   res.setHeader(
     'content-disposition',

--- a/src/pages/api/pdf.ts
+++ b/src/pages/api/pdf.ts
@@ -1,7 +1,10 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import hummus from 'hummus'
-import { TaxForm } from '../../types/TaxForm'
 import streams from 'memory-streams'
+import { TaxForm } from '../../types/TaxForm'
+import { TaxFormUserInput } from '../../types/TaxFormUserInput'
+import { setDate } from '../../lib/utils'
+import { calculate } from '../../lib/calculation'
 
 const FIRST_COLUMN = 31.5
 const BOX_WIDTH = 14.4
@@ -670,11 +673,12 @@ export default async (
   req: NextApiRequest,
   res: NextApiResponse,
 ): Promise<void> => {
-  const form: TaxForm = req.body
-
-  if (!form) {
+  if (!req.body.taxFormUserInput) {
     return res.status(500).json({ error: 'invalid data' })
   }
+
+  const formInput: TaxFormUserInput = JSON.parse(req.body.taxFormUserInput)
+  const form: TaxForm = calculate(setDate(formInput))
 
   res.setHeader(
     'content-disposition',

--- a/src/pages/api/pdf.ts
+++ b/src/pages/api/pdf.ts
@@ -679,7 +679,7 @@ export default async (
   }
 
   const taxFormUserInput: TaxFormUserInput = JSON.parse(rawTaxFormUserInput)
-  const taxForm: TaxForm = calculate(setDate(taxFormUserInput, new Date()))
+  const taxForm: TaxForm = calculate(setDate(taxFormUserInput))
 
   res.setHeader(
     'content-disposition',

--- a/src/pages/api/xml.ts
+++ b/src/pages/api/xml.ts
@@ -9,18 +9,19 @@ export default async (
   req: NextApiRequest,
   res: NextApiResponse,
 ): Promise<void> => {
-  if (!req.body.taxFormUserInput) {
+  const rawTaxFormUserInput = req.body.taxFormUserInput
+  if (!rawTaxFormUserInput) {
     return res.status(500).json({ error: 'invalid data' })
   }
 
-  const formInput: TaxFormUserInput = JSON.parse(req.body.taxFormUserInput)
-  const form: TaxForm = calculate(setDate(formInput))
+  const taxFormUserInput: TaxFormUserInput = JSON.parse(rawTaxFormUserInput)
+  const taxForm: TaxForm = calculate(setDate(taxFormUserInput))
 
   res.setHeader(
     'content-disposition',
     'attachment; filename=danove_priznanie.xml',
   )
   res.writeHead(200, { 'Content-Type': 'text/xml' })
-  res.write(convertToXML(form))
+  res.write(convertToXML(taxForm))
   res.end()
 }

--- a/src/pages/api/xml.ts
+++ b/src/pages/api/xml.ts
@@ -15,7 +15,7 @@ export default async (
   }
 
   const taxFormUserInput: TaxFormUserInput = JSON.parse(rawTaxFormUserInput)
-  const taxForm: TaxForm = calculate(setDate(taxFormUserInput, new Date()))
+  const taxForm: TaxForm = calculate(setDate(taxFormUserInput))
 
   res.setHeader(
     'content-disposition',

--- a/src/pages/api/xml.ts
+++ b/src/pages/api/xml.ts
@@ -1,30 +1,26 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { convertToXML } from '../../lib/xml/xmlConverter'
-import { setDate, parseInputNumber } from '../../lib/utils'
+import { setDate } from '../../lib/utils'
+import { calculate } from '../../lib/calculation'
 import { TaxForm } from '../../types/TaxForm'
+import { TaxFormUserInput } from '../../types/TaxFormUserInput'
 
 export default async (
   req: NextApiRequest,
   res: NextApiResponse,
 ): Promise<void> => {
-  if (!req.body) {
+  if (!req.body.taxFormUserInput) {
     return res.status(500).json({ error: 'invalid data' })
   }
 
-  const form: TaxForm = req.body
-  Object.keys(form).forEach((key) => {
-    const parsedNumber = parseInputNumber(form[key])
-    if (!isNaN(parsedNumber)) {
-      form[key] = parsedNumber
-    }
-  })
+  const formInput: TaxFormUserInput = JSON.parse(req.body.taxFormUserInput)
+  const form: TaxForm = calculate(setDate(formInput))
 
   res.setHeader(
     'content-disposition',
     'attachment; filename=danove_priznanie.xml',
   )
   res.writeHead(200, { 'Content-Type': 'text/xml' })
-
-  res.write(convertToXML(setDate(form)))
+  res.write(convertToXML(form))
   res.end()
 }

--- a/src/pages/api/xml.ts
+++ b/src/pages/api/xml.ts
@@ -1,0 +1,30 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { convertToXML } from '../../lib/xml/xmlConverter'
+import { setDate, parseInputNumber } from '../../lib/utils'
+import { TaxForm } from '../../types/TaxForm'
+
+export default async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+): Promise<void> => {
+  if (!req.body) {
+    return res.status(500).json({ error: 'invalid data' })
+  }
+
+  const form: TaxForm = req.body
+  Object.keys(form).forEach((key) => {
+    const parsedNumber = parseInputNumber(form[key])
+    if (!isNaN(parsedNumber)) {
+      form[key] = parsedNumber
+    }
+  })
+
+  res.setHeader(
+    'content-disposition',
+    'attachment; filename=danove_priznanie.xml',
+  )
+  res.writeHead(200, { 'Content-Type': 'text/xml' })
+
+  res.write(convertToXML(setDate(form)))
+  res.end()
+}

--- a/src/pages/api/xml.ts
+++ b/src/pages/api/xml.ts
@@ -15,7 +15,7 @@ export default async (
   }
 
   const taxFormUserInput: TaxFormUserInput = JSON.parse(rawTaxFormUserInput)
-  const taxForm: TaxForm = calculate(setDate(taxFormUserInput))
+  const taxForm: TaxForm = calculate(setDate(taxFormUserInput, new Date()))
 
   res.setHeader(
     'content-disposition',

--- a/src/pages/stiahnut.tsx
+++ b/src/pages/stiahnut.tsx
@@ -31,9 +31,11 @@ const Stiahnut: Page<{}> = ({ taxForm, taxFormUserInput, previousRoute }) => {
           target="_blank"
           onSubmit={handleSubmit}
         >
-          {Object.keys(taxForm).map((key: string) => (
-            <input key={key} type="hidden" name={key} value={taxForm[key]} />
-          ))}
+          <input
+            type="hidden"
+            name="taxFormUserInput"
+            value={JSON.stringify(taxFormUserInput)}
+          />
           <button
             type="submit"
             className="btn-secondary govuk-button govuk-button--large"
@@ -49,9 +51,11 @@ const Stiahnut: Page<{}> = ({ taxForm, taxFormUserInput, previousRoute }) => {
           target="_blank"
           onSubmit={handleSubmit}
         >
-          {Object.keys(taxForm).map((key: string) => (
-            <input key={key} type="hidden" name={key} value={taxForm[key]} />
-          ))}
+          <input
+            type="hidden"
+            name="taxFormUserInput"
+            value={JSON.stringify(taxFormUserInput)}
+          />
           <button
             type="submit"
             className="btn-secondary govuk-button govuk-button--large"

--- a/src/pages/stiahnut.tsx
+++ b/src/pages/stiahnut.tsx
@@ -1,15 +1,14 @@
 import React, { useState } from 'react'
 import Link from 'next/link'
-import fileDownload from 'js-file-download'
-import { setDate } from '../lib/utils'
-import { convertToXML } from '../lib/xml/xmlConverter'
-import { downloadPdf } from '../lib/api'
 import { Warning } from '../components/Warning'
 import { Page } from '../components/Page'
 
-const Stiahnut: Page<{}> = ({ taxForm, previousRoute }) => {
+const Stiahnut: Page<{}> = ({ taxForm, taxFormUserInput, previousRoute }) => {
   const [didDownload, setDidDownload] = useState<boolean>(false)
-  const [isDownloadingPdf, setIsDownloadingPdf] = useState<boolean>(false)
+
+  function handleSubmit() {
+    setDidDownload(true)
+  }
 
   return (
     <>
@@ -26,33 +25,40 @@ const Stiahnut: Page<{}> = ({ taxForm, previousRoute }) => {
           Stiahnite si súbor do počítača. Použijete ho neskôr na portáli
           Finančnej správy.
         </p>
-        <button
-          type="submit"
-          className="btn-secondary govuk-button govuk-button--large"
-          onClick={() => {
-            const xml = convertToXML(setDate(taxForm))
-            fileDownload(xml, 'danove_priznanie.xml')
-            setDidDownload(true)
-          }}
+        <form
+          action="/api/xml"
+          method="post"
+          target="_blank"
+          onSubmit={handleSubmit}
         >
-          Stiahnuť dáta (XML)
-        </button>
+          {Object.keys(taxForm).map((key: string) => (
+            <input key={key} type="hidden" name={key} value={taxForm[key]} />
+          ))}
+          <button
+            type="submit"
+            className="btn-secondary govuk-button govuk-button--large"
+          >
+            Stiahnuť dáta (XML)
+          </button>
+        </form>
         <p>&nbsp;</p>
         <p>Môžete si stiahnuť aj PDF súbor.</p>
-        <button
-          type="submit"
-          className="btn-secondary govuk-button govuk-button--large"
-          style={{ cursor: isDownloadingPdf ? 'progress' : 'pointer' }}
-          onClick={async () => {
-            setIsDownloadingPdf(true)
-            const pdf = await downloadPdf(taxForm)
-            fileDownload(pdf, 'danove_priznanie.pdf')
-            setIsDownloadingPdf(false)
-          }}
-          disabled={isDownloadingPdf}
+        <form
+          action="/api/pdf"
+          method="post"
+          target="_blank"
+          onSubmit={handleSubmit}
         >
-          Stiahnuť dáta (PDF)
-        </button>
+          {Object.keys(taxForm).map((key: string) => (
+            <input key={key} type="hidden" name={key} value={taxForm[key]} />
+          ))}
+          <button
+            type="submit"
+            className="btn-secondary govuk-button govuk-button--large"
+          >
+            Stiahnuť dáta (PDF)
+          </button>
+        </form>
       </div>
       {!didDownload && (
         <Warning className="govuk-!-margin-top-3">

--- a/src/pages/stiahnut.tsx
+++ b/src/pages/stiahnut.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import { Warning } from '../components/Warning'
 import { Page } from '../components/Page'
 
-const Stiahnut: Page<{}> = ({ taxForm, taxFormUserInput, previousRoute }) => {
+const Stiahnut: Page<{}> = ({ taxFormUserInput, previousRoute }) => {
   const [didDownload, setDidDownload] = useState<boolean>(false)
 
   function handleSubmit() {

--- a/src/pages/vysledky.tsx
+++ b/src/pages/vysledky.tsx
@@ -157,7 +157,7 @@ const Vysledky: Page<Partial<TaxFormUserInput>> = ({
           <EmailForm
             label="Pošleme vám tento výpočet dane na email?"
             hint="Bude sa vám hodiť pri úhrade daní"
-            taxForm={taxForm}
+            taxFormUserInput={taxFormUserInput}
             saveForm={(email, newsletter) => {
               setTaxFormUserInput({ email, newsletter })
             }}


### PR DESCRIPTION
Fixne tieto tri issues:

https://trello.com/c/Z3SmSHPQ/132-ked-je-nahoden%C3%BD-popup-blocker-nechce-stiahnu%C5%A5-s%C3%BAbory-po-pokuse-z-linku-otvori%C5%A5-v-novom-okne-vyhadzuje-chyby-detto-xml-ani-pdf

https://trello.com/c/i5PSzA35/124-testovanie-chyby-pdf-s%C3%BAbor-je-po%C5%A1koden%C3%BD-alebo-pr%C3%A1zdny

https://trello.com/c/B3UrdVyU/130-posielanie-mailu-v-screene-v%C3%BDpo%C4%8Det-dane-za-rok-2019-po-zadan%C3%AD-mailu-na-odoslanie-formul%C3%A1ra-nefunguje-e%C5%A1te-nekomunikuje-so-server

Problem bol v podstate spolocny, data type ked sme poslali request na server sa stratili. Vyriesil som to posielanim `taxFormUserInput` namiesto `taxForm` a prekonvertovanim to spat na `taxForm` na serveri.

JSON.parse 😬 ale zvolil som easy cestu namiesto separatneho inputu pre kazdu hodnotu.